### PR TITLE
Fix build under GCC 8.2.1

### DIFF
--- a/src/platform-plugin/qgtkwindow.cpp
+++ b/src/platform-plugin/qgtkwindow.cpp
@@ -833,3 +833,6 @@ QGtkRefPtr<GtkMenuBar> QGtkWindow::gtkMenuBar() const
     return m_menubar;
 }
 
+QDebug operator<< (QDebug d, const QGtkWindow* window) {
+    return d << static_cast<const QPlatformWindow*>(window);
+}

--- a/src/platform-plugin/qgtkwindow.h
+++ b/src/platform-plugin/qgtkwindow.h
@@ -187,6 +187,8 @@ public:
     Q_INVOKABLE void queueDraw(QGtkWindow *win);
 };
 
+QDebug operator<< (QDebug d, const QGtkWindow* window);
+
 QT_END_NAMESPACE
 
 #endif // QGTKWINDOW_H


### PR DESCRIPTION
Latest HEAD fails to build under fresh Arch Linux with qDebug error:
```
qgtkwindow_render.cpp: In static member function ‘static void QGtkWindow::drawCallback(GtkWidget*, cairo_t*, gpointer)’:
qgtkwindow_render.cpp:45:47: error: ambiguous overload for ‘operator<<’ (operand types are ‘QDebug’ and ‘QGtkWindow*’)
     qCDebug(lcWindowRender) << "drawCallback" << pw;
                                               ^
/usr/include/qt/QtCore/qobject.h:531:22: note: candidate: ‘QDebug operator<<(QDebug, const QObject*)’
 Q_CORE_EXPORT QDebug operator<<(QDebug, const QObject *);
                      ^~~~~~~~
/usr/include/qt/QtGui/5.12.1/QtGui/qpa/qplatformsurface.h:85:21: note: candidate: ‘QDebug operator<<(QDebug, const QPlatformSurface*)’
 Q_GUI_EXPORT QDebug operator<<(QDebug debug, const QPlatformSurface *surface);
                     ^~~~~~~~
```
QGtkPlatform class inherits from both so we need a custom print operator for it to fix this problem.